### PR TITLE
Allow using qml_formatter as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: qml_formatter
+  name: reformat QML files
+  description: Automatic code formatter for QML files.
+  entry: qml_formatter NO_QUESTION
+  language: rust
+  types: [qml]


### PR DESCRIPTION
This allows using this tools as a hook for the [pre-commit framework](https://pre-commit.com/) by adding this to a config file:

```
repos:
  - repo: https://github.com/qarmin/qml_formatter.git
    rev: '' # some git tag or commit ID
    hooks:
      - id: qml_formatter
```