### PR TITLE
fix: invalid reformat on string interpolation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,8 @@ use std::fs::read_to_string;
             fn test_{test_name}() {{
                 let input_content = read_to_string("{input_file}").unwrap();
                 let output_content = read_to_string("{output_file}").unwrap();
-                assert_eq!(convert_file(input_content), output_content);
+                let result_content = convert_file(input_content);
+                assert_eq!(result_content, output_content);
             }}
             "#,
             test_name = test_name,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -118,7 +118,15 @@ pub fn move_elements_inside(lines: Vec<String>) -> Vec<String> {
         let mut count_close_round_bracket = 0;
         let mut count_close_bracket = 0;
         let mut count_close_square_bracket = 0;
+        let mut string_interpolation = false;
         for charr in line.chars() {
+            if charr == '`' {
+                string_interpolation = !string_interpolation;
+                continue;
+            }
+            else if string_interpolation {
+                continue;
+            }
             if charr == '{' {
                 count_open_bracket += 1;
             } else if charr == '}' {
@@ -144,6 +152,9 @@ pub fn move_elements_inside(lines: Vec<String>) -> Vec<String> {
             } else {
                 current_bracket_number -= calculated_ending_brackets;
             }
+        }
+        if string_interpolation {
+            println!("Unclosed template literal, probably QML is broken");
         }
     }
     new_lines

--- a/src/test_data/bracket_with_string_interpolation_INPUT.qml
+++ b/src/test_data/bracket_with_string_interpolation_INPUT.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.12
+
+Column {
+    required property string prop
+
+    Text {
+        text: "test"
+    }
+
+    function func(a, b){
+        return `${a}|${index + 1}]`
+    }
+
+    Row {
+        Column {
+            spacing: 4
+            width: 10
+            Repeater {
+                model: [0, 2]
+
+                Rect {
+                    required property int index
+                    property string foo: func("a", index)
+                }
+            }
+        }
+        Column {
+            spacing: 4
+            width: 10
+            Repeater {
+                model: [0, 2]
+
+                Rect {
+                    required property int index
+                    property string foo:`a|${index + 1}]`
+                }
+            }
+        }
+    }
+}

--- a/src/test_data/bracket_with_string_interpolation_OUTPUT.qml
+++ b/src/test_data/bracket_with_string_interpolation_OUTPUT.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.12
+
+Column {
+    required property string prop
+
+    Text {
+        text: "test"
+    }
+
+    function func(a, b) {
+        return `${a}|${index + 1}]`
+    }
+
+    Row {
+        Column {
+            spacing: 4
+            width: 10
+            Repeater {
+                model: [0, 2]
+
+                Rect {
+                    required property int index
+                    property string foo: func("a", index)
+                }
+            }
+        }
+        Column {
+            spacing: 4
+            width: 10
+            Repeater {
+                model: [0, 2]
+
+                Rect {
+                    required property int index
+                    property string foo:`a|${index + 1}]`
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When using template literals, `qml_formatter` would consider inside curly brackets as if there was part of the QML structure. This commit fixes this behaviour and exclude bracket matching in interpolation.